### PR TITLE
Fix double-wrapped no-network issue in createKnowledgeFromData

### DIFF
--- a/lib/harAnalyzer.js
+++ b/lib/harAnalyzer.js
@@ -267,23 +267,21 @@ export class HarAnalyzer {
 
         if (!('page' in analyzedData) || !analyzedData['page']) {
             knowledgeData['issues']['no-network'] = {
-                'no-network': {
-                    'test': '404',
-                    'rule': 'no-network',
-                    'category': 'technical',
-                    'severity': 'warning',
-                    'subIssues': [
-                        {
-                            'url': url,
-                            'rule': 'no-network',
-                            'category': 'standard',
-                            'severity': 'warning',
-                            'text': `No HTML content found in the HAR file.`,
-                            'line': 0,
-                            'column': 0
-                        }
-                    ]
-                }
+                'test': '404',
+                'rule': 'no-network',
+                'category': 'technical',
+                'severity': 'warning',
+                'subIssues': [
+                    {
+                        'url': url,
+                        'rule': 'no-network',
+                        'category': 'standard',
+                        'severity': 'warning',
+                        'text': `No HTML content found in the HAR file.`,
+                        'line': 0,
+                        'column': 0
+                    }
+                ]
             };
             return knowledgeData;
         }


### PR DESCRIPTION
## Summary

Removes an extra `'no-network'` wrapper object from the issue emitted 
by `createKnowledgeFromData` when the target page could not be loaded. 
The issue now has the same shape as in `plugin-accessibility-statement` 
and the rest of `lib/harAnalyzer.js`.

Fixes #<issue-nummer>.

## Before

```js
knowledgeData.issues = {
  'no-network': {
    'no-network': {            // extra wrapper
      rule: 'no-network',
      severity: 'warning',
      subIssues: [ ... ]
    }
  }
}
```

## After

```js
knowledgeData.issues = {
  'no-network': {
    rule: 'no-network',
    severity: 'warning',
    subIssues: [ ... ]
  }
}
```

## Verification

Tested by running `python default.py -t 2 -u <site> -r -o t2.json` 
against a site that triggers browsertime's `UrlLoadError`. Before 
the fix, this crashes downstream (`Cannot read properties of 
undefined (reading 'length')` in plugin-webperf-core's pug template, 
then `KeyError: 'severity'` in webperf_core). After the fix the test 
completes and reports `no-network` as a warning issue.